### PR TITLE
Update 2 removed methods to current crystal methods

### DIFF
--- a/src/gcf.cr
+++ b/src/gcf.cr
@@ -80,7 +80,7 @@ module GCF
   end
 
   def self.parse_options
-    OptionParser.parse! do |parser|
+    OptionParser.parse do |parser|
       parser.banner = "usage: #{APPBIN} [arguments]"
       parser.on("-h", "--help", "show this help") { puts_safe ""; puts_safe parser; puts_safe ""; exit }
       parser.on("-d", "--deploy", "required to indicate that you intend to deploy") { @@run_deploy = true }

--- a/src/gcf/utils.cr
+++ b/src/gcf/utils.cr
@@ -61,7 +61,7 @@ module GCF
   end
 
   def self.temp_dir(prefix, create = true)
-    dir = "/tmp/#{prefix}-#{Time.now.to_unix}-#{random_string(6)}"
+    dir = "/tmp/#{prefix}-#{Time.utc.to_unix}-#{random_string(6)}"
     FileUtils.mkdir_p dir
     FileUtils.rm_rf dir # delete if existed before
     FileUtils.mkdir_p(dir) if create


### PR DESCRIPTION
OptionParser.parse! and Time#now were both deprecated awhile ago
OptionParser.parse and Time#utc are both backwards compatible changes to
work with both the docker container version build, and crystal v1.2