### PR TITLE
Update Crystal to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/sam0x17/gcf.cr.svg?style=svg)](https://circleci.com/gh/sam0x17/gcf.cr)
 
 GCF provides managed execution of crystal language code within Google Cloud Functions.
-GCF compiles your crystal code statically using the [durosoft/crystal-alpine](https://hub.docker.com/r/durosoft/crystal-alpine/)
+GCF compiles your crystal code statically using the [crystallang/crystal](https://hub.docker.com/r/crystallang/crystal)
 docker image or optionally using your local crystal installation (if it is capable of static compilation) via the `--local` option.
 It then bundles your compiled crystal code in a thin node.js wrapper function and deploys it to GCP using
 the options you specify. An API is also provided for writing to the console, throwing errors, and returning

--- a/build_static
+++ b/build_static
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "compiling..."
-docker run --rm -it -v $PWD:/app -w /app durosoft/crystal-alpine:latest crystal build src/gcf.cr -o gcf --release --static --no-debug --define production
+docker run --rm -it -v $PWD:/app -w /app crystallang/crystal:latest crystal build src/gcf.cr -o gcf --release --static --no-debug --define production
 echo "done."

--- a/shard.lock
+++ b/shard.lock
@@ -1,18 +1,18 @@
-version: 1.0
+version: 2.0
 shards:
+  backtracer:
+    git: https://github.com/sija/backtracer.cr.git
+    version: 1.2.1
+
   exception_page:
-    github: crystal-loot/exception_page
-    version: 0.1.1
+    git: https://github.com/crystal-loot/exception_page.git
+    version: 0.2.1
 
   kemal:
-    github: kemalcr/kemal
-    version: 0.25.0
-
-  kilt:
-    github: jeromegn/kilt
-    version: 0.4.0
+    git: https://github.com/kemalcr/kemal.git
+    version: 1.1.0+git.commit.5e2efec0503622267b57d03fe7d5151000d3bf47
 
   radix:
-    github: luislavena/radix
-    version: 0.3.8
+    git: https://github.com/luislavena/radix.git
+    version: 0.4.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,8 @@ targets:
 dependencies:
   kemal:
     github: kemalcr/kemal
+    branch: master
 
-crystal: 0.28.0
+crystal: 1.2.2
 
 license: MIT

--- a/src/gcf.cr
+++ b/src/gcf.cr
@@ -80,7 +80,7 @@ module GCF
   end
 
   def self.parse_options
-    OptionParser.parse! do |parser|
+    OptionParser.parse do |parser|
       parser.banner = "usage: #{APPBIN} [arguments]"
       parser.on("-h", "--help", "show this help") { puts_safe ""; puts_safe parser; puts_safe ""; exit }
       parser.on("-d", "--deploy", "required to indicate that you intend to deploy") { @@run_deploy = true }
@@ -136,8 +136,8 @@ module GCF
       puts_safe "compiling static binary using local crystal installation: #{`crystal --version`.strip}..."
       comp_result = `#{CRYSTAL_STATIC_BUILD}`
     else
-      puts_safe "compiling static binary using the durosoft/crystal-alpine docker image..."
-      comp_result = `docker pull durosoft/crystal-alpine && docker run --rm -it -v $PWD:/app -w /app durosoft/crystal-alpine #{CRYSTAL_STATIC_BUILD}`
+      puts_safe "compiling static binary using the crystallang/crystal docker image..."
+      comp_result = `docker run --rm -it -v $PWD:/app -w /app crystallang/crystal #{CRYSTAL_STATIC_BUILD}`
     end
     polite_raise! comp_result if comp_result.includes? "error"
     polite_raise! "project did not compile successfully" unless File.exists? "crystal_function"

--- a/src/gcf/utils.cr
+++ b/src/gcf/utils.cr
@@ -61,7 +61,7 @@ module GCF
   end
 
   def self.temp_dir(prefix, create = true)
-    dir = "/tmp/#{prefix}-#{Time.now.to_unix}-#{random_string(6)}"
+    dir = "/tmp/#{prefix}-#{Time.utc.to_unix}-#{random_string(6)}"
     FileUtils.mkdir_p dir
     FileUtils.rm_rf dir # delete if existed before
     FileUtils.mkdir_p(dir) if create


### PR DESCRIPTION
- Use official public crystal docker image (crystallang/crystal)
- Update 2 removed methods to current crystal methods
   OptionParser.parse! and Time#now were both deprecated awhile ago
   OptionParser.parse and Time#utc are both backwards compatible changes to
   work with both the docker container version build, and crystal v1.2